### PR TITLE
[Feat] 종이비행기 버튼, 나침반, 축척 구현

### DIFF
--- a/SanTa/SanTa/MapScene/MapViewController.swift
+++ b/SanTa/SanTa/MapScene/MapViewController.swift
@@ -9,7 +9,7 @@ import MapKit
 class MapViewController: UIViewController {
     weak var coordinator: MapViewCoordinator?
     private var mapView = MKMapView()
-    private var manager: CLLocationManager?
+    private var manager = CLLocationManager()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -22,6 +22,7 @@ class MapViewController: UIViewController {
     private func configureViews() {
         self.mapView = MKMapView(frame: view.bounds)
         self.mapView.showsUserLocation = true
+        self.mapView.delegate = self
         self.view.addSubview(self.mapView)
     }
     
@@ -37,12 +38,11 @@ class MapViewController: UIViewController {
     }
     
     private func configureCoreLocationManager() {
-        self.manager = CLLocationManager()
-        self.manager?.requestWhenInUseAuthorization()
-        self.manager?.requestAlwaysAuthorization()
-        self.manager?.delegate = self
-        self.manager?.desiredAccuracy = kCLLocationAccuracyBest
-        self.manager?.startUpdatingLocation()
+        self.manager.requestWhenInUseAuthorization()
+        self.manager.requestAlwaysAuthorization()
+        self.manager.delegate = self
+        self.manager.desiredAccuracy = kCLLocationAccuracyBest
+        self.manager.startUpdatingLocation()
     }
     
     private func render(_ location: CLLocation) {
@@ -59,22 +59,25 @@ class MapViewController: UIViewController {
     }
     
     private func testCoordinates() {
-        for _ in 0...200 {
+        for _ in 0..<200 {
             let latitude = Double.random(in: 36.0..<37.0)
             let longitude = -Double.random(in: 121.0..<122.0)
-            let pin = MKPointAnnotation()
-            pin.coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
-            mapView.addAnnotation(pin)
+            let mountainAnnotaion = MountainAnnotaion()
+            mountainAnnotaion.coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+            self.mapView.addAnnotation(mountainAnnotaion)
         }
     }
 }
 
 extension MapViewController: MKMapViewDelegate {
     func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
-        return MountainAnnotationView(
-            annotation: annotation,
-            reuseIdentifier: MountainAnnotationView.ReuseID
-        )
+        if let _ = annotation as? MountainAnnotaion {
+            return MountainAnnotationView(
+                annotation: annotation,
+                reuseIdentifier: MountainAnnotationView.ReuseID
+            )
+        }
+        return nil
     }
 }
 
@@ -85,4 +88,8 @@ extension MapViewController: CLLocationManagerDelegate {
             self.render(location)
         }
     }
+}
+
+class MountainAnnotaion: NSObject, MKAnnotation {
+    var coordinate = CLLocationCoordinate2D(latitude: 0, longitude: 0)
 }

--- a/SanTa/SanTa/MapScene/MapViewController.swift
+++ b/SanTa/SanTa/MapScene/MapViewController.swift
@@ -9,7 +9,9 @@ import MapKit
 class MapViewController: UIViewController {
     weak var coordinator: MapViewCoordinator?
     private var mapView = MKMapView()
+    private var startButton = UIButton()
     private var manager = CLLocationManager()
+    private var userTrackingButton = MKUserTrackingButton()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -21,9 +23,49 @@ class MapViewController: UIViewController {
     
     private func configureViews() {
         self.mapView = MKMapView(frame: view.bounds)
-        self.mapView.showsUserLocation = true
-        self.mapView.delegate = self
         self.view.addSubview(self.mapView)
+        self.mapView.showsUserLocation = true
+        self.mapView.showsScale = true
+        self.mapView.showsCompass = true
+        self.mapView.delegate = self
+        
+        self.view.addSubview(self.startButton)
+        self.startButton.backgroundColor = .blue
+        self.startButton.translatesAutoresizingMaskIntoConstraints = false
+        self.startButton.setTitle("시작", for: .normal)
+        self.startButton.setTitleColor(.white, for: .normal)
+        self.startButton.titleLabel?.font = .boldSystemFont(ofSize: 25)
+        self.startButton.layer.cornerRadius = 50
+        self.startButton.layer.shadowColor = UIColor.gray.cgColor
+        self.startButton.layer.shadowOpacity = 1
+        self.startButton.layer.shadowRadius = 3
+        self.startButton.layer.shadowOffset = CGSize(width: 0, height: 3)
+    
+        let startButtonConstraints = [
+            self.startButton.widthAnchor.constraint(equalToConstant: 100),
+            self.startButton.heightAnchor.constraint(equalToConstant: 100),
+            self.startButton.bottomAnchor.constraint(equalTo: self.mapView.bottomAnchor, constant: -150),
+            self.startButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
+        ]
+        NSLayoutConstraint.activate(startButtonConstraints)
+        
+        self.userTrackingButton = .init(mapView: mapView)
+        self.view.addSubview(self.userTrackingButton)
+        self.userTrackingButton.isHidden = true
+        self.userTrackingButton.backgroundColor = .white
+        self.userTrackingButton.translatesAutoresizingMaskIntoConstraints = false
+        self.userTrackingButton.layer.cornerRadius = 10
+        self.userTrackingButton.clipsToBounds = true
+        let userTrackingButtonConstraints = [
+            self.userTrackingButton.widthAnchor.constraint(equalToConstant: 50),
+            self.userTrackingButton.heightAnchor.constraint(equalToConstant: 50),
+            self.userTrackingButton.leftAnchor.constraint(
+                equalTo: self.mapView.rightAnchor,
+                constant: -100
+            ),
+            self.userTrackingButton.centerYAnchor.constraint(equalTo: self.startButton.centerYAnchor)
+        ]
+        NSLayoutConstraint.activate(userTrackingButtonConstraints)
     }
     
     private func registerAnnotationView() {
@@ -86,6 +128,13 @@ extension MapViewController: CLLocationManagerDelegate {
         if let location = locations.first {
             manager.stopUpdatingLocation()
             self.render(location)
+        }
+    }
+    
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        if manager.authorizationStatus == .authorizedWhenInUse ||
+           manager.authorizationStatus == .authorizedAlways {
+            userTrackingButton.isHidden = false
         }
     }
 }


### PR DESCRIPTION
## Issue Number
🔒 Close #29, #30 

### 변경 사항

- 변경된 파일명
  - MapViewController.swift

### 새로운 기능

- 기능 목록
  - 지도 화면을 확대 및 축소할 때에만 축척이 나타 난다
  - 축척이 화면의 너무 큰 부분을 차지하지 않도록 일정 범위 이상에서 단위를 변경한다
  -  종이비행기 버튼을 누르면 현재 위치로 줌 인 된다
  -  한 번 더 누르면 기기가 바라보는 방향으로 화면을 회전시키며 전방을 표시한다
  - 전방을 표시할 때 나침반을 상단에 표시한다
  - 한 번 더 눌러 해제한다

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트

- [x] Merge하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
