### PR TITLE
[Feature] 지도 화면에서 측정 시작 이전에 권한 여부를 확인하기

### DIFF
--- a/SanTa/SanTa/MapScene/MapViewController.swift
+++ b/SanTa/SanTa/MapScene/MapViewController.swift
@@ -56,8 +56,6 @@ class MapViewController: UIViewController {
     private func configureViews() {
         self.mapView = MKMapView(frame: view.bounds)
         guard let mapView = mapView else { return }
-        mapView.showsUserLocation = true
-        mapView.delegate = self
         self.view.addSubview(mapView)
         mapView.showsUserLocation = true
         mapView.showsScale = true

--- a/SanTa/SanTa/MapScene/MapViewController.swift
+++ b/SanTa/SanTa/MapScene/MapViewController.swift
@@ -136,9 +136,26 @@ class MapViewController: UIViewController {
         let region = MKCoordinateRegion(center: coordinate, span: span)
         mapView.setRegion(region, animated: true)
     }
+    
+    private func authAlert() -> UIAlertController {
+        let alert = UIAlertController(title: "위치정보 활성화", message: "지도에 현재 위치를 표시할 수 있도록 위치정보를 활성화해주세요", preferredStyle: .alert)
+        let cancel = UIAlertAction(title: "아니요", style: .cancel)
+        let confirm = UIAlertAction(title: "활성화", style: .default) { _ in
+            guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+            UIApplication.shared.open(url)
+        }
+        alert.addAction(cancel)
+        alert.addAction(confirm)
+        return alert
+    }
 
     @objc private func presentRecordingViewController() {
-        coordinator?.presentRecordingViewController()
+        switch self.manager.authorizationStatus{
+        case .authorizedWhenInUse, .authorizedAlways:
+            self.coordinator?.presentRecordingViewController()
+        default:
+            self.present(authAlert(), animated: false)
+        }
     }
 }
 

--- a/SanTa/SanTa/MapScene/MapViewController.swift
+++ b/SanTa/SanTa/MapScene/MapViewController.swift
@@ -28,10 +28,10 @@ class MapViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        if manager.authorizationStatus == .authorizedAlways ||
-            manager.authorizationStatus == .authorizedWhenInUse {
+        switch self.manager.authorizationStatus {
+        case .authorizedAlways, .authorizedWhenInUse:
             userTrackingButton.isHidden = false
-        } else {
+        default:
             userTrackingButton.isHidden = true
         }
     }
@@ -155,15 +155,17 @@ extension MapViewController: MKMapViewDelegate {
 extension MapViewController: CLLocationManagerDelegate {
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         if let location = locations.first {
-            manager.stopUpdatingLocation()
+            self.manager.stopUpdatingLocation()
             self.render(location)
         }
     }
     
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-        if manager.authorizationStatus == .authorizedWhenInUse ||
-            manager.authorizationStatus == .authorizedAlways {
+        switch self.manager.authorizationStatus {
+        case .authorizedAlways, .authorizedWhenInUse:
             userTrackingButton.isHidden = false
+        default:
+            userTrackingButton.isHidden = true
         }
     }
 }


### PR DESCRIPTION
## Issue Number
🔒 Close #79 

### 변경 사항

- 변경된 파일명
  - MapViewController.swift

### 새로운 기능

- 기능 목록
  - 위치 서비스가 꺼져 있거나 권한이 없다면 알림을 띄운다
  - 알림에서 취소와 활성화를 선택할 수 있다
  - 취소를 선택시 측정화면으로 넘어갈 수 없다
  - 활성화를 선택시 설정화면으로 보내어 권한을 쉽게 활성화할 수 있도록 한다

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트

- [x] Merge하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
