### PR TITLE
[Refactor] 설정화면 뷰 리펙토링

### DIFF
--- a/SanTa/SanTa/SettingsScene/MapOptionCell.swift
+++ b/SanTa/SanTa/SettingsScene/MapOptionCell.swift
@@ -52,6 +52,7 @@ class MapOptionCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         self.configureView()
+        self.configureStackViewAccessibility()
     }
     
     required init?(coder: NSCoder) {
@@ -72,5 +73,15 @@ class MapOptionCell: UITableViewCell {
     func update(option: MapOption) {
         self.title.text = option.text
         self.map.text = option.map.name
+    }
+}
+
+// MARK: - Accessibility
+
+extension MapOptionCell {
+    private func configureStackViewAccessibility() {
+        self.stackView.axis =
+        self.traitCollection.preferredContentSizeCategory < .accessibilityLarge ?
+            .horizontal : .vertical
     }
 }

--- a/SanTa/SanTa/SettingsScene/MapOptionCell.swift
+++ b/SanTa/SanTa/SettingsScene/MapOptionCell.swift
@@ -11,6 +11,15 @@ class MapOptionCell: UITableViewCell {
     
     static let identifier = "MapOptionCell"
     
+    private var stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.distribution = .equalCentering
+        return stackView
+    }()
+    
     private(set) var title: UILabel = {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .caption1)
@@ -63,20 +72,17 @@ class MapOptionCell: UITableViewCell {
     }
 
     private func configureView() {
-        self.contentView.addSubview(self.title)
+        self.stackView.addArrangedSubview(self.title)
+        self.stackView.addArrangedSubview(self.map)
+        
+        self.contentView.addSubview(self.stackView)
         let locationConstrain = [
-            self.title.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor),
-            self.title.leftAnchor.constraint(equalTo: self.contentView.leftAnchor, constant: 30),
+            self.stackView.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: 15),
+            self.stackView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor, constant: -15),
+            self.stackView.leftAnchor.constraint(equalTo: self.contentView.leftAnchor, constant: 30),
+            self.stackView.rightAnchor.constraint(equalTo: self.contentView.rightAnchor, constant: -30),
         ]
         NSLayoutConstraint.activate(locationConstrain)
-        
-        self.contentView.addSubview(self.map)
-        let mapConstrain = [
-            self.map.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor),
-            self.map.rightAnchor.constraint(equalTo: self.contentView.rightAnchor, constant: -30),
-            self.map.leftAnchor.constraint(equalTo: self.title.rightAnchor, constant: 10),
-        ]
-        NSLayoutConstraint.activate(mapConstrain)
     }
     
     func update(option: MapOption) {

--- a/SanTa/SanTa/SettingsScene/MapOptionCell.swift
+++ b/SanTa/SanTa/SettingsScene/MapOptionCell.swift
@@ -10,16 +10,7 @@ import UIKit
 class MapOptionCell: UITableViewCell {
     
     static let identifier = "MapOptionCell"
-    
-    private var stackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.alignment = .center
-        stackView.distribution = .equalCentering
-        return stackView
-    }()
-    
+
     private(set) var title: UILabel = {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .body)
@@ -48,6 +39,16 @@ class MapOptionCell: UITableViewCell {
         return label
     }()
     
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [self.title, self.map])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.distribution = .equalCentering
+        return stackView
+    }()
+    
+    
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         self.configureView()
@@ -56,25 +57,8 @@ class MapOptionCell: UITableViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    override var frame: CGRect {
-        get {
-            return super.frame
-        }
-        set (newFrame) {
-            var frame = newFrame
-            let newWidth = frame.width * 0.90
-            let space = (frame.width - newWidth) / 2
-            frame.size.width = newWidth
-            frame.origin.x += space
-            super.frame = frame
-        }
-    }
 
     private func configureView() {
-        self.stackView.addArrangedSubview(self.title)
-        self.stackView.addArrangedSubview(self.map)
-        
         self.contentView.addSubview(self.stackView)
         let locationConstrain = [
             self.stackView.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: 15),

--- a/SanTa/SanTa/SettingsScene/MapOptionCell.swift
+++ b/SanTa/SanTa/SettingsScene/MapOptionCell.swift
@@ -22,7 +22,7 @@ class MapOptionCell: UITableViewCell {
     
     private(set) var title: UILabel = {
         let label = UILabel()
-        label.font = UIFont.preferredFont(forTextStyle: .caption1)
+        label.font = UIFont.preferredFont(forTextStyle: .body)
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
@@ -35,7 +35,7 @@ class MapOptionCell: UITableViewCell {
     private var map: UILabel = {
         let label = PaddingLabel()
         label.padding(top: 5, bottom: 5, left: 10, right: 10)
-        label.font = UIFont.preferredFont(forTextStyle: .caption2)
+        label.font = UIFont.preferredFont(forTextStyle: .caption1)
         label.adjustsFontForContentSizeCategory = true
         label.textColor = .white
         label.backgroundColor = .darkGray

--- a/SanTa/SanTa/SettingsScene/MapOptionCell.swift
+++ b/SanTa/SanTa/SettingsScene/MapOptionCell.swift
@@ -38,7 +38,7 @@ class MapOptionCell: UITableViewCell {
         label.font = UIFont.preferredFont(forTextStyle: .caption1)
         label.adjustsFontForContentSizeCategory = true
         label.textColor = .white
-        label.backgroundColor = .darkGray
+        label.backgroundColor = UIColor(named: "SantaColor")
         label.translatesAutoresizingMaskIntoConstraints = false
         label.clipsToBounds = true
         label.layer.cornerRadius = 5

--- a/SanTa/SanTa/SettingsScene/ToggleOptionCell.swift
+++ b/SanTa/SanTa/SettingsScene/ToggleOptionCell.swift
@@ -17,6 +17,14 @@ class ToggleOptionCell: UITableViewCell {
     
     weak var delegate: ToggleOptionCellDelegate?
     
+    private var stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        return stackView
+    }()
+    
     private var title: UILabel = {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .caption1)
@@ -70,21 +78,17 @@ class ToggleOptionCell: UITableViewCell {
     }
     
     private func configureView() {
+        self.stackView.addArrangedSubview(self.title)
+        self.stackView.addArrangedSubview(self.controlSwitch)
         
-        self.contentView.addSubview(self.title)
+        self.contentView.addSubview(self.stackView)
         let locationConstrain = [
-            self.title.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor),
-            self.title.leftAnchor.constraint(equalTo: self.contentView.leftAnchor, constant: 30),
+            self.stackView.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: 15),
+            self.stackView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor, constant: -15),
+            self.stackView.leftAnchor.constraint(equalTo: self.contentView.leftAnchor, constant: 30),
+            self.stackView.rightAnchor.constraint(equalTo: self.contentView.rightAnchor, constant: -30),
         ]
         NSLayoutConstraint.activate(locationConstrain)
-        
-        self.contentView.addSubview(self.controlSwitch)
-        let switchConstrain = [
-            self.controlSwitch.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor),
-            self.controlSwitch.rightAnchor.constraint(equalTo: self.contentView.rightAnchor, constant: -30),
-            self.controlSwitch.leftAnchor.constraint(equalTo: self.title.rightAnchor, constant: 10),
-        ]
-        NSLayoutConstraint.activate(switchConstrain)
     }
     
     func update(option: ToggleOption) {

--- a/SanTa/SanTa/SettingsScene/ToggleOptionCell.swift
+++ b/SanTa/SanTa/SettingsScene/ToggleOptionCell.swift
@@ -17,14 +17,6 @@ class ToggleOptionCell: UITableViewCell {
     
     weak var delegate: ToggleOptionCellDelegate?
     
-    private var stackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.alignment = .center
-        return stackView
-    }()
-    
     private var title: UILabel = {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .body)
@@ -46,6 +38,14 @@ class ToggleOptionCell: UITableViewCell {
         return controlSwitch
     }()
     
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [self.title, self.controlSwitch])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        return stackView
+    }()
+    
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         self.selectionStyle = .none
@@ -55,21 +55,7 @@ class ToggleOptionCell: UITableViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    override var frame: CGRect {
-        get {
-            return super.frame
-        }
-        set (newFrame) {
-            var frame = newFrame
-            let newWidth = frame.width * 0.90
-            let space = (frame.width - newWidth) / 2
-            frame.size.width = newWidth
-            frame.origin.x += space
-            super.frame = frame
-        }
-    }
-    
+
     @objc func onClickSwitch(sender: UISwitch) {
         guard let title = self.title.text else { return }
         self.delegate?.toggleOptionCellSwitchChanged(self,
@@ -78,9 +64,6 @@ class ToggleOptionCell: UITableViewCell {
     }
     
     private func configureView() {
-        self.stackView.addArrangedSubview(self.title)
-        self.stackView.addArrangedSubview(self.controlSwitch)
-        
         self.contentView.addSubview(self.stackView)
         let locationConstrain = [
             self.stackView.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: 15),

--- a/SanTa/SanTa/SettingsScene/ToggleOptionCell.swift
+++ b/SanTa/SanTa/SettingsScene/ToggleOptionCell.swift
@@ -27,7 +27,7 @@ class ToggleOptionCell: UITableViewCell {
     
     private var title: UILabel = {
         let label = UILabel()
-        label.font = UIFont.preferredFont(forTextStyle: .caption1)
+        label.font = UIFont.preferredFont(forTextStyle: .body)
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0

--- a/SanTa/SanTa/SettingsScene/ToggleOptionCell.swift
+++ b/SanTa/SanTa/SettingsScene/ToggleOptionCell.swift
@@ -41,7 +41,7 @@ class ToggleOptionCell: UITableViewCell {
         let controlSwitch = UISwitch()
         controlSwitch.translatesAutoresizingMaskIntoConstraints = false
         controlSwitch.addTarget(self, action: #selector(onClickSwitch(sender:)), for: .valueChanged)
-        controlSwitch.onTintColor = .systemBlue
+        controlSwitch.onTintColor = UIColor(named: "SantaColor")
         controlSwitch.setContentCompressionResistancePriority(.init(rawValue: 1000), for: .horizontal)
         return controlSwitch
     }()

--- a/SanTa/SanTa/SettingsScene/ToggleOptionCell.swift
+++ b/SanTa/SanTa/SettingsScene/ToggleOptionCell.swift
@@ -50,6 +50,7 @@ class ToggleOptionCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         self.selectionStyle = .none
         self.configureView()
+        self.configureStackViewAccessibility()
     }
     
     required init?(coder: NSCoder) {
@@ -80,4 +81,12 @@ class ToggleOptionCell: UITableViewCell {
     }
 }
 
+// MARK: - Accessibility
 
+extension ToggleOptionCell {
+    private func configureStackViewAccessibility() {
+        self.stackView.axis =
+        self.traitCollection.preferredContentSizeCategory < .accessibilityLarge ?
+            .horizontal : .vertical
+    }
+}


### PR DESCRIPTION
## Issue Number
🔒 Close #177 

### 변경 사항

- SanTa/SanTa/SettingsScene/MapOptionCell.swift
- SanTa/SanTa/SettingsScene/ToggleOptionCell.swift

### 새로운 기능

- 텍스트 스타일 변경
- Dynamic Type 8단계 초과 크기도 뷰에 반영
- Cell에 있는 View들을 스택뷰로 구현
- Dynamic Type 8단계 초과시 Cell안의 스택뷰를 vertical로 전환

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 체크리스트

- [x] Merge하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
