### PR TITLE
[Feat] 설정 화면에서 사진 권한에 따른 분기처리

### DIFF
--- a/SanTa/SanTa/SettingsScene/SettingsUsecase.swift
+++ b/SanTa/SanTa/SettingsScene/SettingsUsecase.swift
@@ -6,10 +6,10 @@
 //
 
 import Foundation
+import Photos
 
 final class SettingsUsecase {
-    
-    let settingsRepository: SettingsRepository
+    private let settingsRepository: SettingsRepository
     
     init(settingsRepository: SettingsRepository) {
         self.settingsRepository = settingsRepository
@@ -17,6 +17,16 @@ final class SettingsUsecase {
     
     func save<T: Codable>(value: T, key: Settings) {
         self.settingsRepository.save(value: value, key: key)
+    }
+    
+    func photoPermission(completion: @escaping (Bool) -> Void) {
+        let photoPermission = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+        switch photoPermission {
+        case .authorized:
+            completion(true)
+        default:
+            completion(false)
+        }
     }
     
     func makeSettings() -> [[Option]] {

--- a/SanTa/SanTa/SettingsScene/SettingsViewController.swift
+++ b/SanTa/SanTa/SettingsScene/SettingsViewController.swift
@@ -51,6 +51,11 @@ class SettingsViewController: UIViewController {
         self.bind()
         self.viewModel?.viewDidLoad()
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.viewModel?.viewWillAppear()
+    }
 
     private func configureTableView() {
         self.tableView.dataSource = self
@@ -89,6 +94,25 @@ class SettingsViewController: UIViewController {
         self.viewModel?.$settings.sink { [weak self] _ in
             self?.tableView.reloadData()
         }.store(in: &self.subscriptions)
+        self.viewModel?.isPhotoRecordAvailable.sink { [weak self] bool in
+            self?.configurePhotoPermission(bool)
+        }.store(in: &self.subscriptions)
+    }
+    
+    private func configurePhotoPermission(_ bool: Bool) {
+        if !bool {
+            let alert = UIAlertController(title: "사진 권한 활성화", message: "측정하는 동안 사진을 기록할 수 있도록 위치정보를 활성화해주세요", preferredStyle: .alert)
+            let confirm = UIAlertAction(title: "확인", style: .default) { _ in
+                guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+                UIApplication.shared.open(url)
+            }
+            alert.addAction(confirm)
+            self.present(alert, animated: true) {
+                guard let photoSwitchCell = self.tableView.cellForRow(at: IndexPath(row: 0, section: 0)) as? ToggleOptionCell
+                else { return }
+                photoSwitchCell.changeSwitch()
+            }
+        }
     }
     
     private func showMapActionSheet(cellTitle: String) {

--- a/SanTa/SanTa/SettingsScene/SettingsViewModel.swift
+++ b/SanTa/SanTa/SettingsScene/SettingsViewModel.swift
@@ -13,6 +13,7 @@ final class SettingsViewModel {
     @Published var settings: [[Option]] = []
     
     let settingsUseCase: SettingsUsecase
+    let isPhotoRecordAvailable = PassthroughSubject<Bool, Never>()
     
     var sectionCount: Int {
         return settings.count
@@ -26,6 +27,15 @@ final class SettingsViewModel {
         self.reloadSettings()
     }
     
+    func viewWillAppear() {
+        self.settingsUseCase.photoPermission { [weak self] bool in
+            if !bool {
+                self?.settingsUseCase.save(value: false, key: .recordPhoto)
+                self?.reloadSettings()
+            }
+        }
+    }
+    
     func option(indexPath: IndexPath) -> Option {
         return settings[indexPath.section][indexPath.item]
     }
@@ -34,6 +44,15 @@ final class SettingsViewModel {
         self.settingsUseCase.save(value: value, key: key)
         if value is String {
             self.reloadSettings()
+            return
+        }
+        if key == Settings.recordPhoto {
+            self.settingsUseCase.photoPermission { bool in
+                self.isPhotoRecordAvailable.send(bool)
+                if !bool {
+                    self.settingsUseCase.save(value: false, key: .recordPhoto)
+                }
+            }
         }
     }
     


### PR DESCRIPTION
## Issue Number
🔒 Close #308
🔒 Close #309 

### 변경 사항

- 변경된 파일명
  - SettingsUsecase.swift
  - SettingsViewController.swift
  - SettingsViewModel.swift

### 새로운 기능

- 기능 목록
  - 사용자가 사진 권한을 허용하지 않았다면 자동으로 스위치를 off 한다
  - 사용자가 언제든지 설정 앱에서 사진 권한을 해제하여도 자동으로 스위치를 off 한다
  - 사용자가 사진 권한이 없다면 스위치를 켤 수 없다
  - 사진 권한이 없으면 설정창을 띄워 권한을 변경하도록 유도한다

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트

- [x] Merge하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
