### PR TITLE
[Feature] Settingscene 지도에 사진표시 설정 제거

### DIFF
--- a/SanTa/SanTa/MapScene/MapViewController.swift
+++ b/SanTa/SanTa/MapScene/MapViewController.swift
@@ -87,7 +87,7 @@ class MapViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        viewModel?.viewWillAppear()
+        self.viewModel?.viewWillAppear()
     }
     
     private func configureViews() {

--- a/SanTa/SanTa/Persistences/UserDefaultsStorage.swift
+++ b/SanTa/SanTa/Persistences/UserDefaultsStorage.swift
@@ -43,10 +43,6 @@ final class DefaultUserDefaultsStorage: UserDefaultsStorage {
             self.save(value: Settings.recordPhoto.initValue as? Bool,
                       key: .recordPhoto)
         }
-        if !self.exist(key: .photosOnMap) {
-            self.save(value: Settings.photosOnMap.initValue as? Bool,
-                      key: .photosOnMap)
-        }
         if !self.exist(key: .voiceGuidanceEveryOnekm) {
             self.save(value: Settings.voiceGuidanceEveryOnekm.initValue as? Bool,
                       key: .voiceGuidanceEveryOnekm)

--- a/SanTa/SanTa/RecordingTitleScene/RecordingTitleViewController.swift
+++ b/SanTa/SanTa/RecordingTitleScene/RecordingTitleViewController.swift
@@ -22,7 +22,7 @@ class RecordingTitleViewController: UIViewController {
     private let recordingTitle: UILabel = {
         let label = UILabel()
         label.text = "기록 제목"
-        label.font = .boldSystemFont(ofSize: 24)
+        label.font = UIFont.preferredFont(forTextStyle: .title1)
         label.textColor = .systemGray
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -31,7 +31,7 @@ class RecordingTitleViewController: UIViewController {
     private let recordingTitleDescription: UILabel = {
         let label = UILabel()
         label.text = "이 기록에 대한 제목을 입력해주세요."
-        label.font = .systemFont(ofSize: 20)
+        label.font = UIFont.preferredFont(forTextStyle: .body)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()

--- a/SanTa/SanTa/RecordingTitleScene/RecordingTitleViewCoordinator.swift
+++ b/SanTa/SanTa/RecordingTitleScene/RecordingTitleViewCoordinator.swift
@@ -19,27 +19,13 @@ class RecordingTitleViewCoordinator: Coordinator {
     }
 
     func start() {
-        if let recordingCoordinator = parentCoordinator as? RecordingViewCoordinator {
-            recordingCoordinator.recordingViewController.present(recordingTitleViewController, animated: true)
-        } else if let resultDetailCoordinator = parentCoordinator as? ResultDetailViewCoordinator {
-            resultDetailCoordinator.navigationController.viewControllers.last?.present(recordingTitleViewController, animated: true)
-        }
-//        guard let recordingCoordinator = parentCoordinator as? RecordingViewCoordinator else {return}
-        
-//        recordingCoordinator.recordingViewController.present(recordingTitleViewController, animated: true)
+        guard let viewController = self.recordingTitleViewController.delegate as? UIViewController else { return }
+        viewController.present(recordingTitleViewController, animated: true)
     }
     
     func dismiss() {
-        if let recordingCoordinator = parentCoordinator as? RecordingViewCoordinator {
-            recordingCoordinator.recordingViewController.dismiss(animated: true, completion: nil)
-            
-        } else if let resultDetailViewCoordinator = parentCoordinator as? ResultDetailViewCoordinator {
-            resultDetailViewCoordinator.navigationController.viewControllers.last?.dismiss(animated: true, completion: nil)
-        }
-        
-//        guard let recordingCoordinator = parentCoordinator as? RecordingViewCoordinator else { return }
-//        recordingCoordinator.recordingViewController.dismiss(animated: true)
-        
+        guard let viewController = self.recordingTitleViewController.delegate as? UIViewController else { return }
+        viewController.dismiss(animated: true, completion: nil)
         self.parentCoordinator?.childCoordinators.removeLast()
     }
     

--- a/SanTa/SanTa/SettingsScene/Settings.swift
+++ b/SanTa/SanTa/SettingsScene/Settings.swift
@@ -9,7 +9,6 @@ import Foundation
 
 enum Settings: String, CaseIterable {
     case recordPhoto = "사진 기록하기"
-    case photosOnMap = "지도에 사진표시"
     case voiceGuidanceEveryOnekm = "1킬로미터 마다 음성 안내"
     case mapFormat = "지도 형식"
     
@@ -20,8 +19,6 @@ enum Settings: String, CaseIterable {
     var initValue: Any {
         switch self {
         case .recordPhoto:
-            return true
-        case .photosOnMap:
             return true
         case .voiceGuidanceEveryOnekm:
             return true

--- a/SanTa/SanTa/SettingsScene/SettingsUsecase.swift
+++ b/SanTa/SanTa/SettingsScene/SettingsUsecase.swift
@@ -29,25 +29,18 @@ final class SettingsUsecase {
         }
     }
     
-    func makeSettings() -> [[Option]] {
-        var options: [[Option]] = []
-        var photoSettings: [Option] = []
-        var voiceSettings: [Option] = []
-        var mapSetting: [Option] = []
+    func makeSettings() -> [Option] {
+        var options: [Option] = []
         
         self.settingsRepository.makeToggleOption(key: Settings.recordPhoto) { value in
-            photoSettings.append(value)
+            options.append(value)
         }
         self.settingsRepository.makeToggleOption(key: Settings.voiceGuidanceEveryOnekm) { value in
-            voiceSettings.append(value)
+            options.append(value)
         }
         self.settingsRepository.makeMapOption(key: Settings.mapFormat) { value in
-            mapSetting.append(value)
+            options.append(value)
         }
-        
-        options.append(photoSettings)
-        options.append(voiceSettings)
-        options.append(mapSetting)
         
         return options
     }

--- a/SanTa/SanTa/SettingsScene/SettingsUsecase.swift
+++ b/SanTa/SanTa/SettingsScene/SettingsUsecase.swift
@@ -38,9 +38,6 @@ final class SettingsUsecase {
         self.settingsRepository.makeToggleOption(key: Settings.recordPhoto) { value in
             photoSettings.append(value)
         }
-        self.settingsRepository.makeToggleOption(key: Settings.photosOnMap) { value in
-            photoSettings.append(value)
-        }
         self.settingsRepository.makeToggleOption(key: Settings.voiceGuidanceEveryOnekm) { value in
             voiceSettings.append(value)
         }

--- a/SanTa/SanTa/SettingsScene/SettingsViewController.swift
+++ b/SanTa/SanTa/SettingsScene/SettingsViewController.swift
@@ -132,20 +132,16 @@ class SettingsViewController: UIViewController {
 extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
     
     func numberOfSections(in tableView: UITableView) -> Int {
-        return self.viewModel?.sectionCount ?? 0
-    }
-    
-    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 10.0
-    }
-    
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        guard let itemCount = self.viewModel?.settings[section].count else { return 0 }
+        guard let itemCount = self.viewModel?.settingsCount else { return 0 }
         return itemCount
     }
     
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+    
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        switch self.viewModel?.option(indexPath: indexPath) {
+        switch self.viewModel?.settings[indexPath.section] {
         case let option as ToggleOption:
             guard let cell = self.tableView.dequeueReusableCell(withIdentifier: ToggleOptionCell.identifier,
                                                                 for: indexPath) as? ToggleOptionCell

--- a/SanTa/SanTa/SettingsScene/SettingsViewModel.swift
+++ b/SanTa/SanTa/SettingsScene/SettingsViewModel.swift
@@ -10,12 +10,12 @@ import Combine
 
 final class SettingsViewModel {
     
-    @Published var settings: [[Option]] = []
+    @Published var settings: [Option] = []
     
     let settingsUseCase: SettingsUsecase
     let isPhotoRecordAvailable = PassthroughSubject<Bool, Never>()
     
-    var sectionCount: Int {
+    var settingsCount: Int {
         return settings.count
     }
     
@@ -34,10 +34,6 @@ final class SettingsViewModel {
                 self?.reloadSettings()
             }
         }
-    }
-    
-    func option(indexPath: IndexPath) -> Option {
-        return settings[indexPath.section][indexPath.item]
     }
     
     func change<T: Codable>(value: T, key: Settings) {

--- a/SanTa/SettingsSceneTests/SettingsSceneTests.swift
+++ b/SanTa/SettingsSceneTests/SettingsSceneTests.swift
@@ -33,28 +33,26 @@ class SettingsViewModelTests: XCTestCase {
     
     func test_ViewModel은_viewDidLoad시_UseCase의_반환값_settings프로퍼티에_세팅() throws {
         viewModel.viewDidLoad()
-        XCTAssertEqual(viewModel.sectionCount, 3)
+        XCTAssertEqual(viewModel.settingsCount, 3)
     }
     
     func test_ViewModel은_change호출시_문자열이면_settings프로퍼티_업데이트() throws {
         viewModel.change(value: 1, key: .mapFormat)
-        XCTAssertEqual(viewModel.sectionCount, 0)
+        XCTAssertEqual(viewModel.settingsCount, 0)
         
         viewModel.change(value: "string", key: .mapFormat)
-        XCTAssertEqual(viewModel.sectionCount, 3)
+        XCTAssertEqual(viewModel.settingsCount, 3)
     }
     
     func test_UseCase는_repository반환_값에_따른_배열생성() {
         let options = useCase.makeSettings()
 
-        let option1 = options[0][0] as? ToggleOption
-        let option2 = options[0][1] as? ToggleOption
-        let option3 = options[1][0] as? ToggleOption
-        let option4 = options[2][0] as? MapOption
+        let option1 = options[0] as? ToggleOption
+        let option2 = options[1] as? ToggleOption
+        let option3 = options[2] as? MapOption
 
         XCTAssertNotNil(option1)
         XCTAssertNotNil(option2)
         XCTAssertNotNil(option3)
-        XCTAssertNotNil(option4)
     }
 }


### PR DESCRIPTION
## Issue Number
🔒 Close #320 

### 변경 사항

SanTa/SanTa/Persistences/UserDefaultsStorage.swift
SanTa/SanTa/SettingsScene/Settings.swift
SanTa/SanTa/SettingsScene/SettingsUsecase.swift
SanTa/SanTa/SettingsScene/SettingsViewController.swift
SanTa/SanTa/SettingsScene/SettingsViewModel.swift
SanTa/SettingsSceneTests/SettingsSceneTests.swift

### 새로운 기능

- Settingscene 지도에 사진표시 설정 제거

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트

- [x] Merge하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
