### PR TITLE
[Refactor] 기록정보 "-"로 화면 표시일 때 VoiceOver "없음" 으로 실행

### DIFF
--- a/SanTa/SanTa/Scenes/ResultDetailScene/DetailCell.swift
+++ b/SanTa/SanTa/Scenes/ResultDetailScene/DetailCell.swift
@@ -101,11 +101,12 @@ extension DetailCell {
         var label = "\(title)정보. "
         self.stack.arrangedSubviews.forEach {
             let stackView = $0 as? UIStackView
-            guard let contentLabel = (stackView?.arrangedSubviews[0] as? UILabel)?.text,
+            guard var contentLabel = (stackView?.arrangedSubviews[0] as? UILabel)?.text,
                   let contentTitleLabel = (stackView?.arrangedSubviews[1] as? UILabel)?.text
             else {
                 return
             }
+            contentLabel = contentLabel == "-" ? "없음" : contentLabel
             label += "\(contentTitleLabel): \(contentLabel), "
         }
         self.accessibilityLabel = label

--- a/SanTa/SanTa/Scenes/ResultDetailScene/ResultDetailSmallerInfoView.swift
+++ b/SanTa/SanTa/Scenes/ResultDetailScene/ResultDetailSmallerInfoView.swift
@@ -81,7 +81,6 @@ final class ResultDetailSmallerInfoView: UIView {
         stackView.axis = .vertical
         stackView.alignment = .center
         stackView.spacing = 5
-//        stackView.distribution = .fillEqually
         return stackView
     }()
 
@@ -90,7 +89,6 @@ final class ResultDetailSmallerInfoView: UIView {
         stackView.axis = .vertical
         stackView.alignment = .center
         stackView.spacing = 5
-//        stackView.distribution = .fillEqually
         return stackView
     }()
 
@@ -99,7 +97,6 @@ final class ResultDetailSmallerInfoView: UIView {
         stackView.axis = .vertical
         stackView.alignment = .center
         stackView.spacing = 5
-//        stackView.distribution = .fillEqually
         return stackView
     }()
 
@@ -108,7 +105,6 @@ final class ResultDetailSmallerInfoView: UIView {
         stackView.axis = .vertical
         stackView.alignment = .center
         stackView.spacing = 5
-//        stackView.distribution = .fillEqually
         return stackView
     }()
 
@@ -117,7 +113,6 @@ final class ResultDetailSmallerInfoView: UIView {
         stackView.axis = .vertical
         stackView.alignment = .center
         stackView.spacing = 5
-//        stackView.distribution = .fillEqually
         return stackView
     }()
 
@@ -126,7 +121,6 @@ final class ResultDetailSmallerInfoView: UIView {
         stackView.axis = .vertical
         stackView.alignment = .center
         stackView.spacing = 5
-//        stackView.distribution = .fillEqually
         return stackView
     }()
 
@@ -198,12 +192,15 @@ extension ResultDetailSmallerInfoView {
         guard let distance = self.distance.text,
               let time = self.time.text,
               let steps = self.steps.text,
-              let maxAltitude = self.maxAltitude.text,
-              let minAltitude = self.minAltitude.text,
-              let averageSpeed = self.averageSpeed.text
+              var maxAltitude = self.maxAltitude.text,
+              var minAltitude = self.minAltitude.text,
+              var averageSpeed = self.averageSpeed.text
         else {
             return
         }
+        maxAltitude = maxAltitude == "-" ? " 없음" : maxAltitude
+        minAltitude = minAltitude == "-" ? " 없음" : minAltitude
+        averageSpeed = averageSpeed == "-" ? " 없음" : averageSpeed
         self.accessibilityLabel =
         "기록 정보 거리: \(distance)km, 시간: \(time), 걸음: \(steps), 최고고도: \(maxAltitude), 최저고도: \(minAltitude), 평균속도: \(averageSpeed)"
     }


### PR DESCRIPTION
## Issue Number
🔒 Close #381 

### 변경 사항

- SanTa/SanTa/Scenes/ResultDetailScene/DetailCell.swift
- SanTa/SanTa/Scenes/ResultDetailScene/ResultDetailSmallerInfoView.swift

### 새로운 기능

- 기록정보 "-"로 화면 표시일 때 VoiceOver "없음" 으로 실행

### 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

### 체크리스트

- [x] Merge하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
