### PR TITLE
[Fix] 시작 버튼을 누르면 등산 측정이 시작되지 않고 산 정보 화면이 나오는 버그 해결

### DIFF
--- a/SanTa/SanTa.xcodeproj/project.pbxproj
+++ b/SanTa/SanTa.xcodeproj/project.pbxproj
@@ -1558,7 +1558,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				DEVELOPMENT_TEAM = 78F54XW75V;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SanTa/Resources/Info.plist;
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Please allow to use app on background";
@@ -1589,7 +1589,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				DEVELOPMENT_TEAM = 78F54XW75V;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SanTa/Resources/Info.plist;
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Please allow to use app on background";

--- a/SanTa/SanTa/Scenes/MapScene/MapViewCoordinator.swift
+++ b/SanTa/SanTa/Scenes/MapScene/MapViewCoordinator.swift
@@ -39,7 +39,9 @@ final class MapViewCoordinator: Coordinator {
 
 extension MapViewCoordinator {
     func presentRecordingViewController() {
-        if self.childCoordinators.isEmpty {
+        if let recordingViewCoordinator = self.childCoordinators.first(where: { $0 is RecordingViewCoordinator }) {
+            recordingViewCoordinator.start()
+        } else {
             let recordingViewCoordinator = RecordingViewCoordinator(
                 navigationController: self.navigationController,
                 userDefaultsStorage: self.userDefaultsStorage,
@@ -47,8 +49,8 @@ extension MapViewCoordinator {
             )
             self.childCoordinators.append(recordingViewCoordinator)
             recordingViewCoordinator.parentCoordinator = self
+            recordingViewCoordinator.start()
         }
-        childCoordinators.first?.start()
     }
 
     func presentMountainDetailViewController(mountainAnnotation: MountainAnnotation) {

--- a/SanTa/SanTa/Scenes/MountainDetailScene/MountainDetailViewController.swift
+++ b/SanTa/SanTa/Scenes/MountainDetailScene/MountainDetailViewController.swift
@@ -33,6 +33,10 @@ final class MountainDetailViewController: UIViewController {
         super.viewDidLoad()
         self.configureViewModel()
     }
+    
+    deinit {
+        coordinator?.viewControllerDidDeinit()
+    }
 
     private func configureViewModel() {
         self.viewModel?.mountainInfoReceived = { [weak self] mountainDetail in

--- a/SanTa/SanTa/Scenes/MountainDetailScene/MountainDetailViewCoordinator.swift
+++ b/SanTa/SanTa/Scenes/MountainDetailScene/MountainDetailViewCoordinator.swift
@@ -37,7 +37,12 @@ final class MountainDetailViewCoordinator: Coordinator {
             self.navigationController.setNavigationBarHidden(false, animated: true)
             self.navigationController.popViewController(animated: true)
         }
-        self.parentCoordinator?.childCoordinators.removeLast()
+    }
+    
+    func viewControllerDidDeinit() {
+        if let index = parentCoordinator?.childCoordinators.firstIndex(where: { $0 === self }) {
+            self.parentCoordinator?.childCoordinators.remove(at: index)
+        }
     }
 }
 


### PR DESCRIPTION
## Issue Number
🔒 Close #386 

### 원인과 해결

- MountainDetailView를 켠 상태에서
  - X 버튼을 눌렀을 때는 Coordinator의 dismiss() 함수가 호출됩니다.
  - 하지만, 화면을 아래로 끌어 내리는 경우 dismiss() 함수가 호출되지 않습니다.
- 때문에 ParentCoordinator인 MapViewCoordinator는 시작 버튼을 눌렀을 때 childCoordinator가 이미 존재하는 상태가 됩니다.
- childCoordinator가 존재하면 RecordingViewCoordinator를 새로 만들지 않으므로 버그가 발생합니다.
- 때문에 MountainDetailViewController가 deinit되면 반드시 MountainDetailViewCoordinator를 deinit하도록 하였습니다.

### 변경 사항

- SanTa/SanTa.xcodeproj/project.pbxproj
- SanTa/SanTa/Application/AppCoordinator.swift
- SanTa/SanTa/Scenes/MountainDetailScene/MountainDetailViewController.swift
- SanTa/SanTa/Scenes/MountainDetailScene/MountainDetailViewCoordinator.swift

### 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

### 체크리스트

- [x] Merge하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
